### PR TITLE
[CSS] Let syntax highlight be black/white

### DIFF
--- a/_sass/so-simple/_variables.scss
+++ b/_sass/so-simple/_variables.scss
@@ -98,12 +98,12 @@ $youtube-color: #bb0000 !default;
 $xing-color: #006567 !default;
 
 /* Syntax highlighting (base16) colors */
-$base00: #fafafa !default;
+$base00: #000000 !default;
 $base01: #073642 !default;
 $base02: #586e75 !default;
 $base03: #657b83 !default;
 $base04: #839496 !default;
-$base05: #586e75 !default;
+$base05: #ffffff !default;
 $base06: #eee8d5 !default;
 $base07: #fdf6e3 !default;
 $base08: #dc322f !default;


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/7642878/53947832-4f8e0600-40a5-11e9-9594-cdfab3427615.png)

src: https://neowaylabs.github.io/programming/unix-shell-for-data-scientists/

# After
![image](https://user-images.githubusercontent.com/7642878/53947803-40a75380-40a5-11e9-9d72-57d002b7d838.png)

src: https://neowaylabs.lerax.me/programming/unix-shell-for-data-scientists/

Closes #3 