### PR TITLE
[_conf] Remove github build warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
 gemspec
+gem "jekyll", "~> 3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,6 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
-    rake (10.5.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -114,8 +113,8 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0.1)
+  jekyll (~> 3.8)
   jekyll-theme-so-simple!
-  rake (~> 10.0)
 
 BUNDLED WITH
    2.0.1

--- a/_config.yml
+++ b/_config.yml
@@ -14,8 +14,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-theme: jekyll-theme-so-simple
-# remote_theme: mmistakes/so-simple-theme
+
 locale: en-US
 title: "NeowayLabs"
 description: "NeowayLabs Tech-Blog."


### PR DESCRIPTION
This solves the the problem related to theme being vendored and
actually this theme really don't have official support
via https://pages.github.com/themes/