### PR TITLE
Remove docker image build on make blog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_IMG = neowaylabs
+DOCKER_VOLUME_ARGS = -v ${PWD}/images:/app/images -v ${PWD}/_posts:/app/_posts/
 
 all: serve
 
@@ -8,8 +9,8 @@ install-deps:
 	     bundle add jekyll; \
     fi
 
-blog: image
-	docker run -it --rm --network=host $(DOCKER_IMG)
+blog: 
+	docker run -it --rm --network=host $(DOCKER_VOLUME_ARGS) $(DOCKER_IMG)
 
 image:
 	docker build -t $(DOCKER_IMG) .

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Requirements:
 After installing Docker just run:
 
 ```
+make image
 make blog
 ```
 


### PR DESCRIPTION
To preview the blog post was a tedious experience, since, it had to build the docker image all the time.

Now you run `make image` once and `make blog`. The server launches almost instantly and you can write refreshing the page, to see the changes there.

